### PR TITLE
Modified parameters and added default mol name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # cg_param_m3
-Coarse-grained mapping and parametrisation for the Martini 3 forcefield
 
-Run with: ./cg_param_m3 "[SMILES]" [name].gro [name].itp [dimer tuning (0/1)]
+Coarse-grained mapping and parametrisation for the Martini 3 forcefield
+Origin: Miller's cg_param (J. Chem. Theory Comput. 2021, 17, 9, 5777–5791).
+
+Modified the script to generate the itp file with optional Molecule name.
+
+Run with: ./cg_param_m3 "[SMILES]" [name].gro [name].itp [dimer tuning (y/n)]
 
 Outputs .gro and .itp files compatible with Gromacs
+
+## Installation
 
 Dependencies:
 
@@ -18,3 +24,12 @@ $ conda create -c rdkit -n cg_param rdkit numpy scipy requests
 $ conda activate cg_param
 ~~~~
 
+## Run
+```bash
+conda activate cg_param
+python cg_param_m3 "[SMILES]" [name].gro [name].itp name y    # Turn on parameters tuning
+python cg_param_m3 "[SMILES]" [name].gro [name].itp name n    # Turn off parameters tuning
+```
+
+Please cite the original paper (https://pubs.acs.org/doi/10.1021/acs.jctc.1c00322)
+and this project if you used cg_param_m3 in your work.

--- a/cg_param_m3.py
+++ b/cg_param_m3.py
@@ -1063,7 +1063,7 @@ def write_itp(mol_name,bead_types,coords0,charges,all_smi,A_cg,itp_name):
     #writes gromacs topology file
     with open(itp_name,'w') as itp:
         itp.write('[moleculetype]\n')
-        itp.write('MOL    2\n')
+        itp.write(' ' + mol_name + '    2\n')
         virtual,real = write_atoms(itp,A_cg,mol_name,bead_types,charges,all_smi,coords0,ring_beads)
         bonds,constraints,dihedrals = write_bonds(itp,A_cg,ring_beads,real,virtual)
         angles = write_angles(itp,bonds,constraints)

--- a/cg_param_m3.py
+++ b/cg_param_m3.py
@@ -1047,8 +1047,7 @@ def get_masses(all_smi,A_cg,virtual):
         excess_mass = np.sum(A_cg[b])*m_H
         masses.append(frag_mass-excess_mass)
 
-    print(masses)
-    print(virtual)
+    print("Virtual:", virtual)
     #Redistribute virtual masses
     for vsite,refs in virtual.items():
         vmass = masses[vsite]
@@ -1056,9 +1055,9 @@ def get_masses(all_smi,A_cg,virtual):
         for rsite,weight in refs.items():
             masses[rsite] += weight*vmass
 
-    print(masses)
+    print("Mass:", masses)
     return masses
-            
+
 
 def write_itp(mol_name,bead_types,coords0,charges,all_smi,A_cg,itp_name):
     #writes gromacs topology file
@@ -1227,7 +1226,7 @@ def write_virtual_sites(itp,virtual_sites):
         itp.write('{}\n'.format(excl))
 
 smi = sys.argv[1]    
-mol_name = 'MOL'
+mol_name = sys.argv[4] if len(sys.argv) >= 5 else 'MOL'
 
 def get_coords(mol,beads):
     #Calculates coordinates for output gro file
@@ -1300,7 +1299,7 @@ def tune_bead(var_bead,var_type,fix_bead,fix_type):
 
 #Generate molecule object
 smi = sys.argv[1]
-mol_name = 'MOL'
+mol_name = sys.argv[4] if len(sys.argv) >= 5 else 'MOL'
 mol = Chem.MolFromSmiles(smi)
 
 #Coarse-grained mapping
@@ -1310,8 +1309,8 @@ A_cg,beads,ring_beads,path_matrix = mapping(mol,ring_atoms,matched_maps,3)
 non_ring = [b for b in range(len(beads)) if not any(b in ring for ring in ring_beads)]
 
 #Parametrise beads
-tuning = bool(int(sys.argv[4]))
-print(tuning)
+tuning = True if len(sys.argv) < 6 else sys.argv[5] in ["y", "Y"]
+print("Bead parameters tuning:", tuning)
 bead_types,charges,all_smi,DG_data = get_types(beads,mol,ring_beads)
 
 #Generate atomistic conformers


### PR DESCRIPTION
The default program does not support self-defined mol name. I added the parameter before tuning flag, and changed the flag to "y/n" to be more native. Now the command is like:
```bash
conda activate cg_param
python cg_param_m3 "[SMILES]" [name].gro [name].itp name y    # Turn on parameters tuning
python cg_param_m3 "[SMILES]" [name].gro [name].itp name n    # Turn off parameters tuning
```